### PR TITLE
MODIFY: prevent from having multiple rows of same item in cart

### DIFF
--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -5,7 +5,6 @@ const addCart = catchAsync(async (req, res) => {
   const user = req.user;
   const products = req.body;
   const result = await orderService.addCart(user, products);
-  console.log(result);
   if (!result) {
     error = new Error("ADD_CART_CONTROLLER_ERROR");
     error.statusCode = 400;

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -5,6 +5,7 @@ const addCart = catchAsync(async (req, res) => {
   const user = req.user;
   const products = req.body;
   const result = await orderService.addCart(user, products);
+  console.log(result);
   if (!result) {
     error = new Error("ADD_CART_CONTROLLER_ERROR");
     error.statusCode = 400;

--- a/models/orderDao.js
+++ b/models/orderDao.js
@@ -1,7 +1,26 @@
 const dataSource = require("./dataSource");
 const queryRunner = dataSource.createQueryRunner();
 
-const addCart = async (user, products) => {
+const foodExists = async(userId, foodId) => {
+  try {
+    const [foodExists] = await dataSource.query(
+      `
+      SELECT EXISTS (
+        SELECT * FROM order_items oi
+        JOIN orders o ON o.order_items_id = oi.id
+        WHERE user_id = ? AND food_id = ?
+      )`, [userId, foodId]
+    );
+    const [result] = Object.values(foodExists);
+    return !!parseInt(result);
+  } catch (error) {
+    error = new Error("DATASOURCE ERROR");
+    error.statusCode = 500;
+    throw error;
+  }
+}
+
+const addCart = async (userId, foodId, count, price) => {
   await queryRunner.connect();
   await queryRunner.startTransaction();
 
@@ -14,7 +33,7 @@ const addCart = async (user, products) => {
         food_id
       ) VALUES (?, ?, ?);
     `,
-      [products.price, products.count, products.foodId]
+      [price, count, foodId]
     );
     await queryRunner.query(
       `
@@ -23,7 +42,7 @@ const addCart = async (user, products) => {
           order_items_id
         ) VALUES (?, ?);
     `,
-      [user.id, orderItemsResult.insertId]
+      [userId, orderItemsResult.insertId]
     );
 
     await queryRunner.commitTransaction();
@@ -36,6 +55,45 @@ const addCart = async (user, products) => {
     throw err;
   }
 };
+
+const updateFoodCount = async (userId, foodId, count) => {
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try{
+    await dataSource.query(
+      `
+      UPDATE order_items oi
+      JOIN orders o ON o.order_items_id = oi.id
+      JOIN foods f ON f.id = oi.food_id
+      SET oi.order_count = oi.order_count + ?
+      WHERE oi.food_id = ?
+      AND o.user_id = ?
+      `, [count, foodId, userId]
+    );
+
+    await dataSource.query(
+      `
+      UPDATE order_items oi
+      JOIN orders o ON o.order_items_id = oi.id
+      JOIN foods ON foods.id = oi.food_id
+      SET oi.order_price = oi.order_count * foods.price
+      WHERE oi.food_id = ?
+      AND o.user_id = ?
+      `, [foodId, userId]
+    );
+    await queryRunner.commitTransaction();
+    return true;
+  } catch (error) {
+    console.log(error);
+    await queryRunner.rollbackTransaction();
+    error = new Error("DATASOURCE ERROR");
+    error.statusCode = 500;
+    throw error;
+  } finally {
+    await queryRunner.release();
+  }
+}
 
 const getCart = async (user) => {
   try {
@@ -116,8 +174,6 @@ const checkDeleteQuery = async (food_id, userId) => {
 };
 
 const deleteOrderItems = async (food_id, userId) => {
-  const queryRunner = dataSource.createQueryRunner();
-
   await queryRunner.connect();
   await queryRunner.startTransaction();
 
@@ -145,7 +201,9 @@ const deleteOrderItems = async (food_id, userId) => {
 };
 
 module.exports = {
+  foodExists,
   addCart,
+  updateFoodCount,
   getCart,
   modifyOrderCount,
   checkDeleteQuery,

--- a/models/orderDao.js
+++ b/models/orderDao.js
@@ -48,7 +48,6 @@ const addCart = async (userId, foodId, count, price) => {
     await queryRunner.commitTransaction();
     return true;
   } catch (err) {
-    console.log(err);
     await queryRunner.rollbackTransaction();
     err = new Error("DATA_NOT_FOUND");
     err.statusCode = 500;
@@ -85,7 +84,6 @@ const updateFoodCount = async (userId, foodId, count) => {
     await queryRunner.commitTransaction();
     return true;
   } catch (error) {
-    console.log(error);
     await queryRunner.rollbackTransaction();
     error = new Error("DATASOURCE ERROR");
     error.statusCode = 500;
@@ -126,7 +124,6 @@ const getCart = async (user) => {
       [user.id]
     );
   } catch (err) {
-    console.log(err);
     err = new Error("DATA_NOT_FOUND");
     err.statusCode = 500;
     throw err;

--- a/routes/orderRouter.js
+++ b/routes/orderRouter.js
@@ -3,7 +3,7 @@ const orderController = require("../controllers/orderController");
 const { authorization } = require("../utils/authorization");
 const router = express.Router();
 
-router.post("/", authorization, orderController.addCart);
+router.post("", authorization, orderController.addCart);
 router.get("/cart", authorization, orderController.getCart);
 router.patch("", authorization, orderController.modifyOrderCount);
 router.delete("", authorization, orderController.deleteOrder);

--- a/services/orderService.js
+++ b/services/orderService.js
@@ -1,7 +1,21 @@
 const orderDao = require("../models/orderDao");
 
 const addCart = async (user, products) => {
-  return await orderDao.addCart(user, products);
+  try{
+    const userId = user.id;
+    const foodId = products.foodId;
+    const count = products.count;
+    const price = products.price;
+    const foodExists = await orderDao.foodExists(userId, foodId);
+
+    if(foodExists) return await orderDao.updateFoodCount(userId, foodId, count);
+
+    return await orderDao.addCart(userId, foodId, count, price);
+  } catch (err) {
+    err = new Error("NOT ABLE TO ADD TO CART")
+    err.statusCode = 400;
+    throw err;
+  };
 };
 
 const getCart = async (user) => {


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.
- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?

장바구니에서 상품을 개별/선택 삭제 API를 테스트 하던중, 여러가지 경우의 수를 주어 보았고, 

같은 유저가 장바구니 상에 같은 제품이 여러개의 row로 담겨있을 경우
 problem procedure:  1. 상세 페이지에서 수량 설정하고 장바구니에 해당 제품을 처음 담은 후, 
                                  2. 새로고침하거나 다시 해당 제품의 상세 페이지에 들어가 다시 장바구니 담기 request를 보낼때,
           
이전에 만들어진 addCart API는 db에 새로운 row를 생성하며 장바구니에 추가 시킴.

problem: deleteOrderItems API의 경우, 유저 id와 제품 id를 인자롤 받는데, order_items에 같은 상품이지만, 여러 row 가 존재하면,
에러가 난다는 것을 발견. 

그러므로 여러가지 방안의 개선점을 회의하던중 아래 fix 대로 업데이트하기로 함

fix: Service layer의 addCart에서 DAO의 foodExists를 호출
      foodExists(userId, foodId) 를 받아 해당 유저가 request가 들어오고 있는 foodId를 이미 db에 가지고 있는지 확인

1. foodExists = true
    DAO의 updateFoodCount를 호출 -> Transaction을 사용하여  1. 수량 update (original value + input quantity)
                                                                                                   2. 최종 수량에 따른 price 변경 (updated count value * foods.price)
            
2. foodExists = false
    기존에 만들여져 있던 addCart 호출 -> Transaction을 사용하여 1. create row in order_items
                                                                                                    2. create row in orders with userId + pk or the created row in 
                                                                                                        order_items 



- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?

유저들이 원활하게 장바구니에 담고 삭제하는 action을 취할 수 있다.



## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 그리고 상세 내역을 적어주세요.

- 해당 유저에 대한 상품의 유무 확인
- 확인된 값에 따른 API의 대응

## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.

개발자로서 가져야하는 마음가짐을 조금 더 확실하게 느꼈던 것 같습니다.

비록 그 어떤한 사람도 완벽할 수 없고, 아직 새싹이라 코드 작성에 한계가 있는데, 이런 사소한 문제점 조차 용납할 수 없고,
"음? 이 경우의 수가 과연 일어날까?"를 간과하지 않고 어떻게든 해결하려하는 마음가짐을 배웠습니다.
